### PR TITLE
Prevent full screen view from locking

### DIFF
--- a/app/src/main/res/layout/activity_viewers_digital_meter1.xml
+++ b/app/src/main/res/layout/activity_viewers_digital_meter1.xml
@@ -9,6 +9,7 @@
     android:orientation="vertical"
     android:paddingVertical="3dp"
     android:background="@color/colorAccent"
+    android:keepScreenOn="true"
     >
     <TextView
         android:id="@+id/digital_meter1_textview"


### PR DESCRIPTION
At the moment the phone will automatically lock when the full screen view is open. This change prevents that from happening.