### PR TITLE
Remove buildToolsVersion from build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
     compileSdk 35
-    buildToolsVersion = '35.0.0'
 
     namespace "net.nhiroki.bluesquarespeedometer"
     defaultConfig {


### PR DESCRIPTION
Looks like it is not necessary recently and it is good to use one in environment, while preparing new environment