### PR TITLE
Change minSdk from 15 (4.0.3) to 23 (6.0) and update libraries

### DIFF
--- a/.github/workflows/android-connectedcheck.yml
+++ b/.github/workflows/android-connectedcheck.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        api-level: [24, 35]
+        api-level: [23, 35]
 
     steps:
       - name: checkout
@@ -31,30 +31,4 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
-          script: ./gradlew connectedCheck
-
-  test_legacy:
-    name: Android connectedCheck x86
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        api-level: [15]
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      # https://github.com/ReactiveCircus/android-emulator-runner/blob/3a18f5021676582060c2652cb1bc92d9821ff212/README.md
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Android Emulator Runner
-        uses: ReactiveCircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86
           script: ./gradlew connectedCheck

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         versionName "0.1.10"
         versionCode 11
 
-        minSdk 15
+        minSdk 23
         targetSdk 36
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -39,11 +39,11 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.activity:activity-ktx:1.8.2'
+    implementation 'androidx.core:core-ktx:1.18.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.activity:activity-ktx:1.13.0'
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
         \n- Coroutines support libraries for Kotlin
         \n- kotlinx-coroutines-android
         \n- Google Guava
+        \n- JSpecify
     </string>
 
     <!-- Legal English texts -->

--- a/ci/android-connectedcheck.sh
+++ b/ci/android-connectedcheck.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -eux
 
-# Minimum supported version: SDK15
-# In current code, non-English test runs on SDK >=24
+# Minimum supported version: SDK23
 
 for sdkver in 35
 do
@@ -28,7 +27,7 @@ do
     sdkmanager --uninstall "system-images;android-$sdkver;default;x86_64"
 done
 
-for sdkver in 24 15
+for sdkver in 23
 do
     sdkmanager "system-images;android-$sdkver;default;x86"
     echo no | avdmanager create avd -f -n vm$sdkver -k "system-images;android-$sdkver;default;x86"

--- a/ci/license-checker.py
+++ b/ci/license-checker.py
@@ -48,8 +48,12 @@ def main():
             assert(line.startswith('+--- ') or line.startswith('\\--- ') or line.startswith('|    '))
             package_info = line[len('+--- '):].split(':')
             package_fullname = package_info[0]
-            package_name = package_info[1]
-            package_version = package_info[2].split(' -> ')[-1].split(' ')[0]
+            if len(package_info) == 2:
+                package_name = package_info[1].split(' -> ')[0]
+                package_version = package_info[1].split(' -> ')[1].split(' ')[0]
+            else:
+                package_name = package_info[1]
+                package_version = package_info[2].split(' -> ')[-1].split(' ')[0]
 
             library_dict = {
                 'fullname': package_fullname,
@@ -63,6 +67,7 @@ def main():
                     and not package_name.startswith('kotlin-coroutines')\
                     and not package_name.startswith('kotlinx-coroutines')\
                     and not (package_name == 'annotations' and package_fullname == 'org.jetbrains')\
+                    and package_fullname != 'org.jspecify'\
                     and package_fullname != 'com.google.guava':
                 print("Line: " + line)
                 print('ERROR: Unknown package')


### PR DESCRIPTION
I decided not to keep Android 4.0.3 support by not updating libraries.

It is not that older decice users cannot use Blue Square Speedometer anymore, they does not receive updates but installed package keeps running. And older versions of apk fo;es in GitHub Release is yet available.

F-Droid already requires Android 6.0 or later. I think this change would affect almost no one.